### PR TITLE
v1.0.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@develop
+      - uses: HeRoMo/pronto-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Create Github workflow definition yaml file in *.github/workflows* directory of 
 
 This action can be configured by the following input parameters.
 
-| name | reqire | default |
-|---|---|---|
-| github_token | true | -- |
-| commit | false | origin/master |
-| runner | false | pronto |
-| formatters | false | github_status github_pr |
+| name | require | default | description |
+|---|---|---|---|
+| github_token | true | -- |  |
+| commit | false | origin/master | Commit for the diff. |
+| runner | false | pronto | Run only the passed runners. |
+| formatters | false | github_status github_pr | Pick output formatters. |
+| path | false | '.' | Relative path to check. |
 
 see [Pronto usage](https://github.com/prontolabs/pronto#usage).
 
@@ -61,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@v0.5.0
+      - uses: HeRoMo/pronto-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -90,7 +91,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v0.5.0
+        uses: HeRoMo/pronto-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           runner: eslint_npm

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://hero/pronto-action:develop
+  image: docker://hero/pronto-action:1.0.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yaml
+++ b/docker-compose-pronto.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: hero/pronto-action:develop
+    image: hero/pronto-action:1.0.0
     volumes:
       - .:/pronto
     entrypoint: ["pronto"]


### PR DESCRIPTION
## Improve action

- Use docker image directly
- Add new input parameter `path`

## Docker image update
- Upgrade Ruby 2.6.5 -> 2.7.1
- Upgrade Node.js 12.16.1 -> 12.16.3
- Upgdare rubygems
  - brakeman 4.8.0 -> 4.8.2
  - rubocop 0.80.1 -> 0.84.0
  - rubocop-i18n 2.0.1 -> 2.0.2
  - rubocop-md 0.3.1 -> 0.3.2
  - rubocop-minitest 0.6.2 -> 0.9.0
  - rubocop-performance 1.5.2 -> 1.6.0
  - rubocop-rails 2.4.2 -> 2.5.2
  - rubocop-rspec 1.38.1 -> 1.39.0