### PR TITLE
v1.2.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@v1.1.0
+      - uses: HeRoMo/pronto-action@v1.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@v1.1.0
+      - uses: HeRoMo/pronto-action@v1.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -91,7 +91,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.1.0
+        uses: HeRoMo/pronto-action@v1.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           runner: eslint_npm

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://hero/pronto-action:1.1.0
+  image: docker://hero/pronto-action:1.2.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yaml
+++ b/docker-compose-pronto.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: hero/pronto-action:1.1.0
+    image: hero/pronto-action:1.2.0
     volumes:
       - .:/pronto
     entrypoint: ["pronto"]


### PR DESCRIPTION
Pronto-action docker image update
- rubocop from 0.85.1 to 0.88.0
- rubocop-rails from 2.6.0 to 2.7.1
- rubocop-md from 0.3.2 to 0.4.0
- rubocop-minitest from 0.9.0 to 0.10.1
- rubocop-thread_safety from 0.3.4 to 0.4.1
- rubocop-performance from 1.6.1 to 1.7.1
- rubocop-rspec from 1.39.0 to 1.42.0