### PR TITLE
Add publish image workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,5 +1,9 @@
 name: Publish Docker image
 on:
+  push:
+    branches:
+      - master
+      - publish-to-ghcr
   release:
     types: [published]
 jobs:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,15 +3,12 @@ on:
   push:
     branches:
       - master
-      - publish-to-ghcr
   release:
-    types: [published]
+    types: [released]
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
-    if: |
-      !startsWith(github.event.release.tag_name, 'v')
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
           registry: ghcr.io
           repository: HeRoMo/pronto-action
           tag_with_ref: true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -20,4 +20,4 @@ jobs:
           registry: ghcr.io
           repository: heromo/pronto-action
           tag_with_ref: true
-      - run: cat /github/home/.docker/config.json
+      - run: docker ps -a

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -18,5 +18,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
           registry: ghcr.io
-          repository: HeRoMo/pronto-action
+          repository: heromo/pronto-action
           tag_with_ref: true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - publish-to-ghcr
   release:
     types: [released]
 jobs:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,22 @@
+name: Publish Docker image
+# on:
+#   release:
+#     types: [published]
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          repository: HeRoMo/pronto-action
+          tag_with_ref: true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -20,4 +20,4 @@ jobs:
           registry: ghcr.io
           repository: heromo/pronto-action
           tag_with_ref: true
-      - run: docker ps -a
+      - run: cat /home/runner/work/_temp/_github_home/.docker/config.json

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - publish-to-ghcr
   release:
     types: [released]
 jobs:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -8,12 +8,12 @@ on:
     types: [released]
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Packages
+    name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to GitHub Packages
+      - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -20,3 +20,4 @@ jobs:
           registry: ghcr.io
           repository: heromo/pronto-action
           tag_with_ref: true
+      - run: cat /github/home/.docker/config.json

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,14 +1,13 @@
 name: Publish Docker image
-# on:
-#   release:
-#     types: [published]
 on:
-  pull_request:
-    types: [opened, synchronize]
+  release:
+    types: [published]
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
+    if: |
+      !startsWith(github.event.release.tag_name, 'v')
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -20,4 +20,3 @@ jobs:
           registry: ghcr.io
           repository: heromo/pronto-action
           tag_with_ref: true
-      - run: cat /home/runner/work/_temp/_github_home/.docker/config.json


### PR DESCRIPTION
Add github workflow to publish docker image to Github Container Registry

refs:
- [Pushing and pulling Docker images \- GitHub Docs](https://docs.github.com/en/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images)
- [Publishing Docker images \- GitHub Docs](https://docs.github.com/en/actions/language-and-framework-guides/publishing-docker-images)
- [docker/build\-push\-action: Build\+push official Docker GitHub action](https://github.com/docker/build-push-action)