### PR TITLE
v1.4.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@v1.3.0
+      - uses: HeRoMo/pronto-action@v1.4.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@v1.3.0
+      - uses: HeRoMo/pronto-action@v1.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -88,11 +88,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.x'
+          node-version: '12.18.x'
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.3.0
+        uses: HeRoMo/pronto-action@v1.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           runner: eslint_npm

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:latest
+  image: docker://ghcr.io/heromo/pronto-action:v1.4.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:v1.4.0
+  image: docker://ghcr.io/heromo/pronto-action:1.4.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://hero/pronto-action:1.3.0
+  image: docker://hero/pronto-action:latest
   entrypoint: '/pronto/entrypoint.sh'

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://hero/pronto-action:latest
+  image: docker://ghcr.io/heromo/pronto-action:latest
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yaml
+++ b/docker-compose-pronto.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: hero/pronto-action:1.3.0
+    image: ghcr.io/heromo/pronto-action:1.4.0
     volumes:
       - .:/pronto
     entrypoint: ["pronto"]


### PR DESCRIPTION
- Upgrade Node.js 12.16.3 -> 12.18.3
- Update gems
  - rubocop 0.88.0 -> 0.90.0
  - rubocop-performance 1.7.1 -> 1.8.0
  - rubocop-rails 2.7.1 -> 2.8.0
  - rubocop-rspec 1.42.0 -> 1.43.2	
  - brakeman 4.8.2 -> 4.9.1
  - sorbet 0.5.5848 -> 0.5.5891
- Change Docker image registry from Dockerhub to Github Container Registry