### PR TITLE
pronto-rubocop: support github suggestions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'pronto'
 gem 'pronto-brakeman', require: false
 gem 'pronto-eslint_npm', require: false
 gem 'pronto-rails_best_practices', require: false
-gem 'pronto-rubocop', require: false
+gem 'pronto-rubocop', branch: 'master', github: 'prontolabs/pronto-rubocop', require: false
 gem 'pronto-scss', require: false
 gem 'pronto-slim_lint', require: false
 gem 'pronto-sorbet', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/prontolabs/pronto-rubocop
+  revision: 170abfe959f5f267cee658a325be1aa79aba0cd0
+  branch: master
+  specs:
+    pronto-rubocop (0.10.0)
+      pronto (~> 0.10.0)
+      rubocop (>= 0.49.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -54,9 +63,6 @@ GEM
     pronto-rails_best_practices (0.10.0)
       pronto (~> 0.10.0)
       rails_best_practices (~> 1.16, >= 1.15.0)
-    pronto-rubocop (0.10.0)
-      pronto (~> 0.10.0)
-      rubocop (~> 0.50, >= 0.49.1)
     pronto-scss (0.10.0)
       pronto (~> 0.10.0)
       scss_lint (~> 0.43, >= 0.43.0)
@@ -158,7 +164,7 @@ DEPENDENCIES
   pronto-brakeman
   pronto-eslint_npm
   pronto-rails_best_practices
-  pronto-rubocop
+  pronto-rubocop!
   pronto-scss
   pronto-slim_lint
   pronto-sorbet


### PR DESCRIPTION
`pronto-rubocop` gem now supports Github Suggestions feature.

https://github.com/prontolabs/pronto-rubocop#suggestions

But unfortunately, these changes have not been released yeat. (only in master branch now)
https://github.com/prontolabs/pronto-rubocop/issues/47

Would be awesome to test it out ;-)