### PR TITLE
Upgrade langs and gems

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-action@v1.15.0
+      - uses: HeRoMo/pronto-action@v1.16.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: HeRoMo/pronto-actionv1.15.0
+      - uses: HeRoMo/pronto-action@v1.16.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -95,7 +95,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-actionv1.15.0
+        uses: HeRoMo/pronto-action@v1.16.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           runner: eslint_npm

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:1.15.0
+  image: docker://ghcr.io/heromo/pronto-action:1.16.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yml
+++ b/docker-compose-pronto.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: ghcr.io/heromo/pronto-action:1.15.0
+    image: ghcr.io/heromo/pronto-action:1.16.0
     volumes:
       - .:/app
     entrypoint: ["bundle", "exec", "pronto"]


### PR DESCRIPTION
## Upgrade Languages

- Ruby 2.7.2 -> 2.7.3
- Node 14.16.0 -> 14.16.1

## Update Gems

- rubocop 1.12.0 -> 1.13.0
- rubocop-minitest 0.11.0 -> 0.12.0
- rubocop-performance 1.10.2 -> 1.11.0
- sorbet 0.5.6357 -> 0.5.6388