### PR TITLE
v1.27.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.26.0
+      - uses: HeRoMo/pronto-action@v1.27.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.26.0
+      - uses: HeRoMo/pronto-action@v1.27.0
 ```
 
 ### For running eslint_npm runner
@@ -97,7 +97,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.26.0
+        uses: HeRoMo/pronto-action@v1.27.0
         with:
           runner: eslint_npm
 ```
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.26.0
+      - uses: HeRoMo/pronto-action@v1.27.0
 ```
 
 ## LICENSE

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:1.26.0
+  image: docker://ghcr.io/heromo/pronto-action:1.27.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yml
+++ b/docker-compose-pronto.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: ghcr.io/heromo/pronto-action:1.26.0
+    image: ghcr.io/heromo/pronto-action:1.27.0
     volumes:
       - .:/app
     entrypoint: ["bundle", "exec", "pronto"]


### PR DESCRIPTION
## upgrade langs

- node 14.18.0 -> 16.13.0

## upgrade gems

- brakeman 5.1.1 -> 5.1.2
- rails_best_practices 1.21.0 -> 1.22.1
- rubocop 1.22.0 -> 1.23.0
- rubocop-ast 1.12.0 -> 1.13.0
- rubocop-minitest 0.15.1 -> 0.17.0
- rubocop-performance 1.11.5 -> 1.12.0
- rubocop-rails 2.12.2 -> 2.12.4
- rubocop-rspec 2.5.0 -> 2.6.0
