### PR TITLE
v1.28.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.27.0
+      - uses: HeRoMo/pronto-action@v1.28.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.27.0
+      - uses: HeRoMo/pronto-action@v1.28.0
 ```
 
 ### For running eslint_npm runner
@@ -97,7 +97,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.27.0
+        uses: HeRoMo/pronto-action@v1.28.0
         with:
           runner: eslint_npm
 ```
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.27.0
+      - uses: HeRoMo/pronto-action@v1.28.0
 ```
 
 ## LICENSE

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:1.27.0
+  image: docker://ghcr.io/heromo/pronto-action:1.28.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yml
+++ b/docker-compose-pronto.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: ghcr.io/heromo/pronto-action:1.27.0
+    image: ghcr.io/heromo/pronto-action:1.28.0
     volumes:
       - .:/app
     entrypoint: ["bundle", "exec", "pronto"]


### PR DESCRIPTION
## Update langs

- Ruby 2.7.4 -> 2.7.5
- Node 16.13.0 -> 16.13.1

## Updated gems

- pronto-brakeman 0.11.0 -> 0.11.1
- rubocop 1.23.0 -> 1.24.0
- rubocop-ast 1.13.0 -> 1.15.1
- rubocop-performance 1.12.0 -> 1.13.0
- rubocop-rails 2.12.4 -> 2.13.0
- rubocop-rspec 2.6.0 -> 2.7.0
- sorbet 0.5.9363 -> 0.5.9464
