### PR TITLE
v1.37.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.36.0
+      - uses: HeRoMo/pronto-action@v1.37.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.36.0
+      - uses: HeRoMo/pronto-action@v1.37.0
 ```
 
 ### For running eslint_npm runner
@@ -109,7 +109,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.36.0
+        uses: HeRoMo/pronto-action@v1.37.0
         with:
           runner: eslint_npm
 ```
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.36.0
+      - uses: HeRoMo/pronto-action@v1.37.0
 ```
 
 ## LICENSE

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:1.36.0
+  image: docker://ghcr.io/heromo/pronto-action:1.37.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yml
+++ b/docker-compose-pronto.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: ghcr.io/heromo/pronto-action:1.36.0
+    image: ghcr.io/heromo/pronto-action:1.37.0
     volumes:
       - .:/app
     entrypoint: ["bundle", "exec", "pronto"]


### PR DESCRIPTION
## Update lang
- Node.js 16.16.0 -> 16.17.0

## Updated gems
- rubocop 1.34.1 -> 1.36.0
- rubocop-minitest 0.21.0 -> 0.22.1
- rubocop-performance 1.14.3 -> 1.15.0
- rubocop-rails 2.15.2 -> 2.16.1
- rubocop-rspec 2.12.1 -> 2.13.2

## New support rubocop extentions
- rubocop-graphq 0.14.6
- rubocop-packaging 0.5.2
- rubocop-sorbet 0.6.11