### PR TITLE
v1.40.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.39.0
+      - uses: HeRoMo/pronto-action@v1.40.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.39.0
+      - uses: HeRoMo/pronto-action@v1.40.0
 ```
 
 ### For running eslint_npm runner
@@ -110,7 +110,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.39.0
+        uses: HeRoMo/pronto-action@v1.40.0
         with:
           runner: eslint_npm
 ```
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.39.0
+      - uses: HeRoMo/pronto-action@v1.40.0
 ```
 
 ## LICENSE

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:1.39.0
+  image: docker://ghcr.io/heromo/pronto-action:1.40.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yml
+++ b/docker-compose-pronto.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: ghcr.io/heromo/pronto-action:1.39.0
+    image: ghcr.io/heromo/pronto-action:1.40.0
     volumes:
       - .:/app
     entrypoint: ["bundle", "exec", "pronto"]


### PR DESCRIPTION
## Update lang

- Node.js 18.12.0 -> 18.12.1

## Update gems

- pronto-rubocop 0.11.2 -> 0.11.3
- rails_best_practices 1.23.1 -> 1.23.2
- rubocop 1.37.1 -> 1.38.0
- rubocop-graphql 0.16.0 -> 0.18.0
- rubocop-minitest 0.22.2 -> 0.23.2
- rubocop-rspec 2.14.2 -> 2.15.0
- sorbet 0.5.10520 -> 0.5.10554

