### PR TITLE
v1.46.0

### DIFF
--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@1.45.0
+      - uses: HeRoMo/pronto-action@1.46.0
         with:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.45.0
+      - uses: HeRoMo/pronto-action@v1.46.0
 ```
 
 ### For running eslint_npm runner
@@ -110,7 +110,7 @@ jobs:
       - name: yarn install
         run: yarn install
       - name: pronto run
-        uses: HeRoMo/pronto-action@v1.45.0
+        uses: HeRoMo/pronto-action@v1.46.0
         with:
           runner: eslint_npm
 ```
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: HeRoMo/pronto-action@v1.45.0
+      - uses: HeRoMo/pronto-action@v1.46.0
 ```
 
 ## LICENSE

--- a/action.yaml
+++ b/action.yaml
@@ -27,5 +27,5 @@ inputs:
     default: '.'
 runs:
   using: 'docker'
-  image: docker://ghcr.io/heromo/pronto-action:1.45.0
+  image: docker://ghcr.io/heromo/pronto-action:1.46.0
   entrypoint: '/pronto/entrypoint.sh'

--- a/docker-compose-pronto.yml
+++ b/docker-compose-pronto.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pronto:
-    image: ghcr.io/heromo/pronto-action:1.45.0
+    image: ghcr.io/heromo/pronto-action:1.46.0
     volumes:
       - .:/app
     entrypoint: ["bundle", "exec", "pronto"]


### PR DESCRIPTION
## Update language

- Node.js 18.14.0 -> 18.14.2

## Update gems

- brakeman 5.4.0 -> 5.4.1
- rubocop 1.45.1 -> 1.47.0
- rubocop-capybara 2.17.0 -> 2.17.1
- rubocop-graphql 0.19.0 -> 1.0.0
- rubocop-minitest 0.27.0 -> 0.28.0
- rubocop-rails 2.17.4 -> 2.18.0
- sorbet 0.5.10658 -> 0.5.10696