### PR TITLE
update rubocop-rails from 2.20.2 to 2.21.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     rubocop-performance (1.19.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.20.2)
+    rubocop-rails (2.21.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)


### PR DESCRIPTION
[Release RuboCop Rails 2.21.0 · rubocop/rubocop-rails](https://github.com/rubocop/rubocop-rails/releases/tag/v2.21.0)